### PR TITLE
libgui: Add guards around mPictureProfileHandle

### DIFF
--- a/libs/gui/BLASTBufferQueue.cpp
+++ b/libs/gui/BLASTBufferQueue.cpp
@@ -299,10 +299,12 @@ void BLASTBufferQueue::update(const sp<SurfaceControl>& surface, uint32_t width,
         t.setFlags(mSurfaceControl, layer_state_t::eEnableBackpressure,
                    layer_state_t::eEnableBackpressure);
         // Migrate the picture profile handle to the new surface control.
+#if COM_ANDROID_GRAPHICS_LIBUI_FLAGS_APPLY_PICTURE_PROFILES
         if (com_android_graphics_libgui_flags_apply_picture_profiles() &&
             mPictureProfileHandle.has_value()) {
             t.setPictureProfileHandle(mSurfaceControl, *mPictureProfileHandle);
         }
+#endif // COM_ANDROID_GRAPHICS_LIBUI_FLAGS_APPLY_PICTURE_PROFILES
         applyTransaction = true;
     }
     mTransformHint = mSurfaceControl->getTransformHint();
@@ -684,6 +686,7 @@ status_t BLASTBufferQueue::acquireNextBufferLocked(
     if (!bufferItem.mIsAutoTimestamp) {
         t->setDesiredPresentTime(bufferItem.mTimestamp);
     }
+#if COM_ANDROID_GRAPHICS_LIBUI_FLAGS_APPLY_PICTURE_PROFILES
     if (com_android_graphics_libgui_flags_apply_picture_profiles() &&
         bufferItem.mPictureProfileHandle.has_value()) {
         t->setPictureProfileHandle(mSurfaceControl, *bufferItem.mPictureProfileHandle);
@@ -695,6 +698,7 @@ status_t BLASTBufferQueue::acquireNextBufferLocked(
             mPictureProfileHandle = std::nullopt;
         }
     }
+#endif // COM_ANDROID_GRAPHICS_LIBUI_FLAGS_APPLY_PICTURE_PROFILES
 
     // Drop stale frame timeline infos
     while (!mPendingFrameTimelines.empty() &&

--- a/libs/gui/BufferQueueProducer.cpp
+++ b/libs/gui/BufferQueueProducer.cpp
@@ -1059,7 +1059,9 @@ status_t BufferQueueProducer::queueBuffer(int slot,
         item.mIsAutoTimestamp = isAutoTimestamp;
         item.mDataSpace = dataSpace;
         item.mHdrMetadata = hdrMetadata;
+#if COM_ANDROID_GRAPHICS_LIBUI_FLAGS_APPLY_PICTURE_PROFILES
         item.mPictureProfileHandle = pictureProfileHandle;
+#endif // COM_ANDROID_GRAPHICS_LIBUI_FLAGS_APPLY_PICTURE_PROFILES
         item.mFrameNumber = currentFrameNumber;
         item.mSlot = slot;
         item.mFence = acquireFence;

--- a/libs/gui/include/gui/BufferItem.h
+++ b/libs/gui/include/gui/BufferItem.h
@@ -94,9 +94,11 @@ class BufferItem : public Flattenable<BufferItem> {
     // mHdrMetadata is the HDR metadata associated with this buffer slot.
     HdrMetadata mHdrMetadata;
 
+#if COM_ANDROID_GRAPHICS_LIBUI_FLAGS_APPLY_PICTURE_PROFILES
     // mPictureProfileHandle is a handle that points to a set of parameters that configure picture
     // processing hardware to enhance the quality of buffer contents.
     std::optional<PictureProfileHandle> mPictureProfileHandle;
+#endif // COM_ANDROID_GRAPHICS_LIBUI_FLAGS_APPLY_PICTURE_PROFILES
 
     // mFrameNumber is the number of the queued frame for this slot.
     uint64_t mFrameNumber;


### PR DESCRIPTION
This is only enabled on trunk_staging anyway and removing it from BufferItem struct fixes QCOM WFD.

Change-Id: I1ac42ae927f927e07565819743296a43cf143b12